### PR TITLE
Make email settings configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,12 @@ ENV WALLABAG_VERSION=2.0.5 \
     SYMFONY__ENV__DATABASE_NAME=symfony \
     SYMFONY__ENV__DATABASE_USER=root \
     SYMFONY__ENV__DATABASE_PASSWORD=~ \
-    SYMFONY__ENV__SECRET=ovmpmAWXRCabNlMgzlzFXDYmCFfzGv
+    SYMFONY__ENV__SECRET=ovmpmAWXRCabNlMgzlzFXDYmCFfzGv \
+    SYMFONY__ENV__MAILER_HOST=127.0.0.1 \
+    SYMFONY__ENV__MAILER_USER=~ \
+    SYMFONY__ENV__MAILER_PASSWORD=~ \
+    SYMFONY__ENV__FROM_EMAIL=wallabag@example.com
+
 
 RUN echo "@testing http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
  && apk add --update \

--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ Default login is `wallabag:wallabag`.
 - `-e SYMFONY__ENV__DATABASE_USER=...` (defaults to "root", this is the name of the database user to use)
 - `-e SYMFONY__ENV__DATABASE_PASSWORD=...` (defaults to "~", this is the password of the database user to use)
 - `-e SYMFONY__ENV__SECRET=...` (defaults to "ovmpmAWXRCabNlMgzlzFXDYmCFfzGv")
-
+- `-e SYMFONY__ENV__MAILER_HOST=...`  defaults to "127.0.0.1", the SMTP host)
+- `-e SYMFONY__ENV__MAILER_USER=...` (defaults to "~", the SMTP user)
+- `-e SYMFONY__ENV__MAILER_PASSWORD=...`(defaults to "~", the SMTP password)
+- `-e SYMFONY__ENV__FROM_EMAIL=...`(defaults to "wallabag@example.com", the address wallabag uses for outgoing emails)
 ## sqlite
 
 The easiest way to start wallabag is to use the sqlite backend. You can spin that up with
@@ -69,6 +72,10 @@ services:
       - SYMFONY__ENV__DATABASE_NAME=wallabag
       - SYMFONY__ENV__DATABASE_USER=wallabag
       - SYMFONY__ENV__DATABASE_PASSWORD=wallapass
+      - SYMFONY__ENV__MAILER_HOST=127.0.0.1
+      - SYMFONY__ENV__MAILER_USER=~
+      - SYMFONY__ENV__MAILER_PASSWORD=~
+      - SYMFONY__ENV__FROM_EMAIL=wallabag@example.com
     ports:
       - "80"
   db:
@@ -78,6 +85,7 @@ services:
     volumes:
       - /opt/wallabag:/var/lib/mysql
 ```
+Note that you must fill out the mail related variables according to your mail config.
 
 ## nginx
 

--- a/root/var/www/wallabag/app/config/parameters.yml
+++ b/root/var/www/wallabag/app/config/parameters.yml
@@ -17,9 +17,9 @@ parameters:
     test_database_path: "%kernel.root_dir%/../data/db/wallabag_test.sqlite"
 
     mailer_transport:  smtp
-    mailer_host:       127.0.0.1
-    mailer_user:       ~
-    mailer_password:   ~
+    mailer_host:       %env.mailer_host%
+    mailer_user:       %env.mailer_user%
+    mailer_password:   %env.mailer_password%
 
     locale:            en
 
@@ -28,9 +28,9 @@ parameters:
 
     # two factor stuff
     twofactor_auth: true
-    twofactor_sender: no-reply@wallabag.org
+    twofactor_sender: %env.from_email%
 
     # fosuser stuff
     fosuser_confirmation: true
 
-    from_email: no-reply@wallabag.org
+    from_email: %env.from_email%


### PR DESCRIPTION
Hi!

Because the standard approach of using localhost as a mail server doesn't work in docker images, I added a few environment variables to make the email settings configurable with e.g. docker-compose.