### PR TITLE
Increase max body size from nginx

### DIFF
--- a/root/etc/nginx/nginx.conf
+++ b/root/etc/nginx/nginx.conf
@@ -23,6 +23,7 @@ http {
     gzip on;
     gzip_disable "msie6";
     open_file_cache max=100;
+    client_max_body_size 50M;
 
 
     upstream php-upstream {


### PR DESCRIPTION
With the default client_max_body_size (1M), import cannot be used.
Raise the limit to 50M.

Maybe this parameter should be configurable via an environment variable?