### PR TITLE
Add .s6-svscan/finish.

### DIFF
--- a/root/etc/s6/.s6-svscan/finish
+++ b/root/etc/s6/.s6-svscan/finish
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /bin/true


### PR DESCRIPTION
Enables a clean shutdown of the docker container, i.e. removes the following error messages while shutting down:
```
s6-svscan: warning: unable to exec finish script .s6-svscan/finish: No such file or directory
s6-svscan: warning: executing into .s6-svscan/crash
s6-svscan: fatal: unable to exec .s6-svscan/crash: No such file or directory
```