### PR TITLE
Install php7-zlib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN echo "@testing http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/
       php7-phar@testing \
       php7-session@testing \
       php7-xml@testing \
+      php7-zlib@testing \
       php7@testing\
       py-mysqldb \
       py-psycopg2 \


### PR DESCRIPTION
If php7-zlib is missing the pocket importer worker dies on a exception because gzuncompress is undefined.