### PR TITLE
MariaDB default encoding utf8mb4 and maintenance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.5
-MAINTAINER Marvin Steadfast <marvin@xsteadfastx.org>
+
+LABEL maintainer "Marvin Steadfast <marvin@xsteadfastx.org>"
 
 ARG WALLABAG_VERSION=2.2.2
-ARG POSTGRES_USER=postgres
 
 RUN set -ex \
  && echo "@testing http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
@@ -41,23 +41,19 @@ RUN set -ex \
       py-simplejson \
       s6 \
       tar \
- && rm -rf /var/cache/apk/*
-
-RUN ln -s /usr/bin/php7 /usr/bin/php \
+ && rm -rf /var/cache/apk/* \
+ && ln -s /usr/bin/php7 /usr/bin/php \
  && ln -sf /dev/stdout /var/log/nginx/access.log \
- && ln -sf /dev/stderr /var/log/nginx/error.log
-
-RUN curl -s http://getcomposer.org/installer | php \
- && mv composer.phar /usr/local/bin/composer
-
-RUN git clone --branch $WALLABAG_VERSION --depth 1 https://github.com/wallabag/wallabag.git /var/www/wallabag
+ && ln -sf /dev/stderr /var/log/nginx/error.log \
+ && curl -s http://getcomposer.org/installer | php \
+ && mv composer.phar /usr/local/bin/composer \
+ && git clone --branch $WALLABAG_VERSION --depth 1 https://github.com/wallabag/wallabag.git /var/www/wallabag
 
 COPY root /
 
 RUN cd /var/www/wallabag \
- && SYMFONY_ENV=prod composer install --no-dev -o --prefer-dist
-
-RUN chown -R nobody:nobody /var/www/wallabag
+ && SYMFONY_ENV=prod composer install --no-dev -o --prefer-dist \
+ && chown -R nobody:nobody /var/www/wallabag
 
 EXPOSE 80
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG WALLABAG_VERSION=2.2.2
 
 RUN set -ex \
  && echo "@testing http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
- && apk add --update \
+ && apk add --no-cache \
       ansible \
       curl \
       git \
@@ -15,7 +15,6 @@ RUN set -ex \
       nginx \
       pcre \
       php7 \
-      php7-amqp \
       php7-amqp@testing \
       php7-bcmath \
       php7-ctype \
@@ -41,7 +40,6 @@ RUN set -ex \
       py-simplejson \
       s6 \
       tar \
- && rm -rf /var/cache/apk/* \
  && ln -s /usr/bin/php7 /usr/bin/php \
  && ln -sf /dev/stdout /var/log/nginx/access.log \
  && ln -sf /dev/stderr /var/log/nginx/error.log \
@@ -51,7 +49,8 @@ RUN set -ex \
 
 COPY root /
 
-RUN cd /var/www/wallabag \
+RUN set -ex \
+ && cd /var/www/wallabag \
  && SYMFONY_ENV=prod composer install --no-dev -o --prefer-dist \
  && chown -R nobody:nobody /var/www/wallabag
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer "Marvin Steadfast <marvin@xsteadfastx.org>"
 ARG WALLABAG_VERSION=2.2.2
 
 RUN set -ex \
+ && echo "@edge http://dl-4.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
  && echo "@testing http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
  && apk add --no-cache \
       ansible \
@@ -38,6 +39,7 @@ RUN set -ex \
       py-mysqldb \
       py-psycopg2 \
       py-simplejson \
+      rabbitmq-c@edge \
       s6 \
       tar \
  && ln -s /usr/bin/php7 /usr/bin/php \

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ $ docker exec -t NAME_OR_ID_OF_YOUR_WALLABAG_CONTAINER /var/www/wallabag/bin/con
 It's a good way to use [docker-compose](https://docs.docker.com/compose/). Example:
 
 ```
-version: '2'
+version: '3'
 services:
   wallabag:
     image: wallabag/wallabag

--- a/root/etc/ansible/entrypoint.yml
+++ b/root/etc/ansible/entrypoint.yml
@@ -70,6 +70,7 @@
         login_port={{ database_port }}
         login_user=root
         login_password="{{ database_root_password_mariadb }}"
+        encoding="utf8mb4"
       notify: run install
       when: (database_driver == 'pdo_mysql') and
             (populate_database == True)


### PR DESCRIPTION
* MariaDB encoding is set when creating DB through the entrypoint
* Cleaning Dockerfile
  * Removed `POSTGRES_USER`
  * Combined run commands
  * Changed deprecated `MAINTAINER` to `LABEL`