### PR TITLE
Allow for file-based environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ env:
   - DB_TYPE=sqlite
   - DB_TYPE=mariadb
   - DB_TYPE=postgresql
+  - DB_TYPE=sqlite-file
+  - DB_TYPE=mariadb-file
+  - DB_TYPE=postgresql-file
 
 install:
   - docker-compose -f tests/docker-compose.$DB_TYPE.yml build

--- a/README.md
+++ b/README.md
@@ -15,21 +15,33 @@ Default login is `wallabag:wallabag`.
 ## Environment variables
 
 - `-e MYSQL_ROOT_PASSWORD=...` (needed for the mariadb container to initialise and for the entrypoint in the wallabag container to create a database and user if its not there)
+- `-e MYSQL_ROOT_PASSWORD_FILE=...` (points to a file, takes precedence over *MYSQL_ROOT_PASSWORD*)
 - `-e POSTGRES_PASSWORD=...` (needed for the posgres container to initialise and for the entrypoint in the wallabag container to create a database and user if not there)
+- `-e POSTGRES_PASSWORD_FILE=...` (points to a file, takes precedence over *POSTGRES_PASSWORD*)
 - `-e POSTGRES_USER=...` (needed for the posgres container to initialise and for the entrypoint in the wallabag container to create a database and user if not there)
+- `-e POSTGRES_USER_FILE=...` (points to a file, takes precedence over *POSTGRES_USER*)
 - `-e SYMFONY__ENV__DATABASE_DRIVER=...` (defaults to "pdo_sqlite", this sets the database driver to use)
 - `-e SYMFONY__ENV__DATABASE_HOST=...` (defaults to "127.0.0.1", if use mysql this should be the name of the mariadb container)
 - `-e SYMFONY__ENV__DATABASE_PORT=...` (port of the database host)
-- `-e SYMFONY__ENV__DATABASE_NAME=...`(defaults to "symfony", this is the name of the database to use)
+- `-e SYMFONY__ENV__DATABASE_NAME=...` (defaults to "symfony", this is the name of the database to use)
+- `-e SYMFONY__ENV__DATABASE_NAME_FILE=...` (points to a file, takes precedence over *SYMFONY__ENV__DATABASE_NAME*)
 - `-e SYMFONY__ENV__DATABASE_USER=...` (defaults to "root", this is the name of the database user to use)
+- `-e SYMFONY__ENV__DATABASE_USER_FILE=...` (points to a file, takes precedence over *SYMFONY__ENV__DATABASE_USER*)
 - `-e SYMFONY__ENV__DATABASE_PASSWORD=...` (defaults to "~", this is the password of the database user to use)
+- `-e SYMFONY__ENV__DATABASE_PASSWORD_FILE=...` (points to a file, takes precedence over *SYMFONY__ENV__DATABASE_PASSWORD*)
 - `-e SYMFONY__ENV__SECRET=...` (defaults to "ovmpmAWXRCabNlMgzlzFXDYmCFfzGv")
+- `-e SYMFONY__ENV__SECRET_FILE=...` (points to a file, takes precedence over *SYMFONY__ENV__SECRET*)
 - `-e SYMFONY__ENV__MAILER_HOST=...`  defaults to "127.0.0.1", the SMTP host)
 - `-e SYMFONY__ENV__MAILER_USER=...` (defaults to "~", the SMTP user)
 - `-e SYMFONY__ENV__MAILER_PASSWORD=...`(defaults to "~", the SMTP password)
+- `-e SYMFONY__ENV__MAILER_PASSWORD_FILE=...` (points to a file, takes precedence over *SYMFONY__ENV__MAILER_PASSWORD*)
 - `-e SYMFONY__ENV__FROM_EMAIL=...`(defaults to "wallabag@example.com", the address wallabag uses for outgoing emails)
 - `-e SYMFONY__ENV__FOSUSER_REGISTRATION=...`(defaults to "true", enable or disable public user registration)
 - `-e POPULATE_DATABASE=...`(defaults to "True". Does the DB has to be populated or is it an existing one)
+
+The enviromnemt variables ending in *_FILE* point to a filename which contains the value. If always takes precedence over the ones without the *_FILE* suffix.
+When there is no valid file found, the 'normal' environment variable will still be used if it is defined, or else it's default value.
+These environment variables can be uses with docker secrets for instance which mounts the secrets as files under the directory */run/secrets/{secret_name}*.
 
 ## SQLite
 

--- a/root/etc/ansible/entrypoint.yml
+++ b/root/etc/ansible/entrypoint.yml
@@ -7,21 +7,109 @@
     database_driver: "{{ lookup('env', 'SYMFONY__ENV__DATABASE_DRIVER')|default('pdo_sqlite', true) }}"
     database_host: "{{ lookup('env', 'SYMFONY__ENV__DATABASE_HOST')|default('127.0.0.1', true) }}"
     database_name: "{{ lookup('env', 'SYMFONY__ENV__DATABASE_NAME')|default('symfony', true) }}"
+    database_name_file: "{{ lookup('env', 'SYMFONY__ENV__DATABASE_NAME_FILE') }}"
     database_password: "{{ lookup('env', 'SYMFONY__ENV__DATABASE_PASSWORD')|default('~', true) }}"
+    database_password_file: "{{ lookup('env', 'SYMFONY__ENV__DATABASE_PASSWORD_FILE') }}"
     database_port: "{{ lookup('env', 'SYMFONY__ENV__DATABASE_PORT')|default('~', true) }}"
     database_root_password_mariadb: "{{ lookup('env', 'MYSQL_ROOT_PASSWORD') }}"
+    database_root_password_mariadb_file: "{{ lookup('env', 'MYSQL_ROOT_PASSWORD_FILE') }}"
     database_root_user_postgres: "{{ lookup('env', 'POSTGRES_USER') }}"
+    database_root_user_postgres_file: "{{ lookup('env', 'POSTGRES_USER_FILE') }}"
     database_root_password_postgres: "{{ lookup('env', 'POSTGRES_PASSWORD') }}"
+    database_root_password_postgres_file: "{{ lookup('env', 'POSTGRES_PASSWORD_FILE') }}"
     database_user: "{{ lookup('env', 'SYMFONY__ENV__DATABASE_USER')|default('root', true) }}"
+    database_user_file: "{{ lookup('env', 'SYMFONY__ENV__DATABASE_USER_FILE') }}"
     populate_database: "{{ lookup('env', 'POPULATE_DATABASE')|default(True, true) }}"
     secret: "{{ lookup('env', 'SYMFONY__ENV__SECRET')|default('ovmpmAWXRCabNlMgzlzFXDYmCFfzGv', true) }}"
+    secret_file: "{{ lookup('env', 'SYMFONY__ENV__SECRET_FILE') }}"
     mailer_host: "{{ lookup('env', 'SYMFONY__ENV__MAILER_HOST')|default('127.0.0.1', true) }}"
     mailer_user: "{{ lookup('env', 'SYMFONY__ENV__MAILER_USER')|default('~', true) }}"
     mailer_password: "{{ lookup('env', 'SYMFONY__ENV__MAILER_PASSWORD')|default('~', true) }}"
+    mailer_password_file: "{{ lookup('env', 'SYMFONY__ENV__MAILER_PASSWORD_FILE') }}"
     from_email: "{{ lookup('env', 'SYMFONY__ENV__FROM_EMAIL')|default('wallabag@example.com', true) }}"
     registration: "{{ lookup('env', 'SYMFONY__ENV__FOSUSER_REGISTRATION')|default('true', true) }}"
 
   tasks:
+
+    - name: get database_name_file
+      stat:
+        path: "{{ database_name_file }}"
+      register: e_database_name_file
+
+    - name: set database_name_file
+      set_fact:
+        database_name: "{{ lookup('file', database_name_file) }}"
+      when: e_database_name_file.stat.exists == True
+
+    - name: get database_password_file
+      stat:
+        path: "{{ database_password_file }}"
+      register: e_database_password_file
+
+    - name: set database_password_file
+      set_fact:
+        database_password: "{{ lookup('file', database_password_file) }}"
+      when: e_database_password_file.stat.exists == True
+
+    - name: get database_root_password_mariadb_file
+      stat:
+        path: "{{ database_root_password_mariadb_file }}"
+      register: e_database_root_password_mariadb_file
+
+    - name: set database_root_password_mariadb_file
+      set_fact:
+        database_root_password_mariadb: "{{ lookup('file', database_root_password_mariadb_file) }}"
+      when: e_database_root_password_mariadb_file.stat.exists == True
+
+    - name: get database_root_password_postgres_file
+      stat:
+        path: "{{ database_root_password_postgres_file }}"
+      register: e_database_root_password_postgres_file
+
+    - name: set database_root_password_postgres_file
+      set_fact:
+        database_root_password_postgres: "{{ lookup('file', database_root_password_postgres_file) }}"
+      when: e_database_root_password_postgres_file.stat.exists == True
+
+    - name: get database_root_user_postgres_file
+      stat:
+        path: "{{ database_root_user_postgres_file }}"
+      register: e_database_root_user_postgres_file
+
+    - name: set database_root_user_postgres_file
+      set_fact:
+        database_root_user_postgres: "{{ lookup('file', database_root_user_postgres_file) }}"
+      when: e_database_root_user_postgres_file.stat.exists == True
+
+    - name: get database_user_file
+      stat:
+        path: "{{ database_user_file }}"
+      register: e_database_user_file
+
+    - name: set database_user_file
+      set_fact:
+        database_user: "{{ lookup('file', database_user_file) }}"
+      when: e_database_user_file.stat.exists == True
+
+    - name: get secret_file
+      stat:
+        path: "{{ secret_file }}"
+      register: e_secret_file
+
+    - name: set secret_file
+      set_fact:
+        secret: "{{ lookup('file', secret_file) }}"
+      when: e_secret_file.stat.exists == True
+
+    - name: get mailer_password_file
+      stat:
+        path: "{{ mailer_password_file }}"
+      register: e_mailer_password_file
+
+    - name: set mailer_password_file
+      set_fact:
+        mailer_password: "{{ lookup('file', mailer_password_file) }}"
+      when: e_mailer_password_file.stat.exists == True
 
     - name: needed dirs
       file:
@@ -150,3 +238,4 @@
         recurse=yes
         owner=nobody
         group=nobody
+

--- a/tests/docker-compose.mariadb-file.yml
+++ b/tests/docker-compose.mariadb-file.yml
@@ -1,0 +1,30 @@
+version: '2'
+services:
+  wallabag:
+    build:
+      context: ../
+    image: wallabag:mariadb
+    container_name: wallabag
+    environment:
+      - MYSQL_ROOT_PASSWORD_FILE=/run/secrets/mysql_password
+      - SYMFONY__ENV__SECRET_FILE=/run/secrets/secret_file
+      - SYMFONY__ENV__DATABASE_DRIVER=pdo_mysql
+      - SYMFONY__ENV__DATABASE_HOST=db
+      - SYMFONY__ENV__DATABASE_PORT=3306
+      - SYMFONY__ENV__DATABASE_NAME_FILE=/run/secrets/database_name
+      - SYMFONY__ENV__DATABASE_USER_FILE=/run/secrets/database_user
+      - SYMFONY__ENV__DATABASE_PASSWORD_FILE=/run/secrets/database_password
+    ports:
+      - "127.0.0.1:80:80"
+    volumes:
+      - ./secrets/database_password:/run/secrets/mysql_password:ro
+      - ./secrets/secret_file:/run/secrets/secret_file:ro
+      - ./secrets/database_name:/run/secrets/database_name:ro
+      - ./secrets/database_user:/run/secrets/database_user:ro
+      - ./secrets/database_password:/run/secrets/database_password:ro
+  db:
+    image: mariadb
+    environment:
+      - MYSQL_ROOT_PASSWORD_FILE=/run/secrets/database_password
+    volumes:
+      - ./secrets/database_password:/run/secrets/database_password:ro

--- a/tests/docker-compose.postgresql-file.yml
+++ b/tests/docker-compose.postgresql-file.yml
@@ -29,3 +29,6 @@ services:
     environment:
       - POSTGRES_PASSWORD_FILE=/run/secrets/postgres_password
       - POSTGRES_USER_FILE=/run/secrets/postgres_user
+    volumes:
+      - ./secrets/database_password:/run/secrets/postgres_password:ro
+      - ./secrets/database_user:/run/secrets/postgres_user:ro

--- a/tests/docker-compose.postgresql-file.yml
+++ b/tests/docker-compose.postgresql-file.yml
@@ -1,0 +1,31 @@
+version: '2'
+services:
+  wallabag:
+    build:
+      context: ../
+    image: wallabag:postgresql
+    container_name: wallabag
+    environment:
+      - POSTGRES_PASSWORD_FILE=/run/secrets/postgres_password
+      - POSTGRES_USER_FILE=/run/secrets/postgres_user
+      - SYMFONY__ENV__SECRET_FILE=/run/secrets/secret_file
+      - SYMFONY__ENV__DATABASE_DRIVER=pdo_pgsql
+      - SYMFONY__ENV__DATABASE_HOST=db
+      - SYMFONY__ENV__DATABASE_PORT=5432
+      - SYMFONY__ENV__DATABASE_NAME_FILE=/run/secrets/database_name
+      - SYMFONY__ENV__DATABASE_USER_FILE=/run/secrets/database_user
+      - SYMFONY__ENV__DATABASE_PASSWORD_FILE=/run/secrets/database_password
+    ports:
+      - "127.0.0.1:80:80"
+    volumes:
+      - ./secrets/database_password:/run/secrets/postgres_password:ro
+      - ./secrets/database_user:/run/secrets/postgres_user:ro
+      - ./secrets/secret_file:/run/secrets/secret_file:ro
+      - ./secrets/database_name:/run/secrets/database_name:ro
+      - ./secrets/database_user:/run/secrets/database_user:ro
+      - ./secrets/database_password:/run/secrets/database_password:ro
+  db:
+    image: postgres
+    environment:
+      - POSTGRES_PASSWORD_FILE=/run/secrets/postgres_password
+      - POSTGRES_USER_FILE=/run/secrets/postgres_user

--- a/tests/docker-compose.sqlite-file.yml
+++ b/tests/docker-compose.sqlite-file.yml
@@ -1,0 +1,22 @@
+version: '2'
+services:
+  wallabag:
+    build:
+      context: ../
+    image: wallabag:sqlite
+    container_name: wallabag
+    environment:
+      - SYMFONY__ENV__DATABASE_DRIVER=pdo_sqlite
+      - SYMFONY__ENV__DATABASE_HOST=127.0.0.1
+      - SYMFONY__ENV__DATABASE_PORT=~
+      - SYMFONY__ENV__DATABASE_NAME_FILE=/run/secrets/database_name
+      - SYMFONY__ENV__DATABASE_USER_FILE=/run/secrets/database_user
+      - SYMFONY__ENV__DATABASE_PASSWORD_FILE=/run/secrets/database_password
+      - SYMFONY__ENV__SECRET_FILE=/run/secrets/secret_file
+    ports:
+      - "127.0.0.1:80:80"
+    volumes:
+      - ./secrets/secret_file:/run/secrets/secret_file:ro
+      - ./secrets/database_name:/run/secrets/database_name:ro
+      - ./secrets/database_user:/run/secrets/database_user:ro
+      - ./secrets/database_password:/run/secrets/database_password:ro

--- a/tests/docker-compose.sqlite.yml
+++ b/tests/docker-compose.sqlite.yml
@@ -11,7 +11,7 @@ services:
       - SYMFONY__ENV__DATABASE_PORT=~
       - SYMFONY__ENV__DATABASE_NAME=symfony
       - SYMFONY__ENV__DATABASE_USER=root
-      - SYMFONY__ENV_DATABASE_PASSWORD=~
+      - SYMFONY__ENV__DATABASE_PASSWORD=~
       - SYMFONY__ENV__SECRET=F00B4R
     ports:
       - "127.0.0.1:80:80"

--- a/tests/secrets/database_name
+++ b/tests/secrets/database_name
@@ -1,0 +1,1 @@
+wallabagDB

--- a/tests/secrets/database_password
+++ b/tests/secrets/database_password
@@ -1,0 +1,1 @@
+supersecretDBpassword

--- a/tests/secrets/database_user
+++ b/tests/secrets/database_user
@@ -1,0 +1,1 @@
+wallabagDBUser

--- a/tests/secrets/mysql_password
+++ b/tests/secrets/mysql_password
@@ -1,0 +1,1 @@
+supersecretMySqlpassword

--- a/tests/secrets/postgres_user
+++ b/tests/secrets/postgres_user
@@ -1,0 +1,1 @@
+postgresUser

--- a/tests/secrets/postgress_password
+++ b/tests/secrets/postgress_password
@@ -1,0 +1,1 @@
+supersecretPostgrespassword

--- a/tests/secrets/secret_file
+++ b/tests/secrets/secret_file
@@ -1,0 +1,1 @@
+rsIN2GybI2l74IcMzbqLIjSyUK6MYq


### PR DESCRIPTION
Allows for file content to be set as the environment variable.
Useful for e.g. docker secrets were the secret is mounted as a file in /run/secrets/{filename}