### PR TITLE
Support Postgres 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Default login is `wallabag:wallabag`.
 - `-e POSTGRES_PASSWORD=...` (needed for the posgres container to initialise and for the entrypoint in the wallabag container to create a database and user if not there)
 - `-e POSTGRES_USER=...` (needed for the posgres container to initialise and for the entrypoint in the wallabag container to create a database and user if not there)
 - `-e SYMFONY__ENV__DATABASE_DRIVER=...` (defaults to "pdo_sqlite", this sets the database driver to use)
+- `-e SYMFONY__ENV__DATABASE_DRIVER_CLASS=...` (sets the database driver class to use)
 - `-e SYMFONY__ENV__DATABASE_HOST=...` (defaults to "127.0.0.1", if use mysql this should be the name of the mariadb container)
 - `-e SYMFONY__ENV__DATABASE_PORT=...` (port of the database host)
 - `-e SYMFONY__ENV__DATABASE_NAME=...`(defaults to "symfony", this is the name of the database to use)
@@ -62,7 +63,7 @@ For using PostgreSQL you have to define some environment variables with the cont
 
 ```
 $ docker run --name wallabag-db -e "POSTGRES_PASSWORD=my-secret-pw" -e "POSTGRES_USER=my-super-user" -d postgres:9.6
-$ docker run --name wallabag --link wallabag-db:wallabag-db -e "POSTGRES_PASSWORD=my-secret-pw" -e "POSTGRES_USER=my-super-user" -e "SYMFONY__ENV__DATABASE_DRIVER=pdo_pgsql" -e "SYMFONY__ENV__DATABASE_HOST=wallabag-db" -e "SYMFONY__ENV__DATABASE_PORT=5432" -e "SYMFONY__ENV__DATABASE_NAME=wallabag" -e "SYMFONY__ENV__DATABASE_USER=wallabag" -e "SYMFONY__ENV__DATABASE_PASSWORD=wallapass" -p 80:80 wallabag/wallabag
+$ docker run --name wallabag --link wallabag-db:wallabag-db -e "POSTGRES_PASSWORD=my-secret-pw" -e "POSTGRES_USER=my-super-user" -e "SYMFONY__ENV__DATABASE_DRIVER=pdo_pgsql" -e 'SYMFONY__ENV__DATABASE_DRIVER_CLASS=Wallabag\CoreBundle\Doctrine\DBAL\Driver\CustomPostgreSQLDriver' -e "SYMFONY__ENV__DATABASE_HOST=wallabag-db" -e "SYMFONY__ENV__DATABASE_PORT=5432" -e "SYMFONY__ENV__DATABASE_NAME=wallabag" -e "SYMFONY__ENV__DATABASE_USER=wallabag" -e "SYMFONY__ENV__DATABASE_PASSWORD=wallapass" -p 80:80 wallabag/wallabag
 ```
 
 ## Redis

--- a/root/etc/ansible/entrypoint.yml
+++ b/root/etc/ansible/entrypoint.yml
@@ -5,6 +5,7 @@
   vars:
 
     database_driver: "{{ lookup('env', 'SYMFONY__ENV__DATABASE_DRIVER')|default('pdo_sqlite', true) }}"
+    database_driver_class: "{{ lookup('env', 'SYMFONY__ENV__DATABASE_DRIVER_CLASS')|default('~', true) }}"
     database_host: "{{ lookup('env', 'SYMFONY__ENV__DATABASE_HOST')|default('127.0.0.1', true) }}"
     database_name: "{{ lookup('env', 'SYMFONY__ENV__DATABASE_NAME')|default('symfony', true) }}"
     database_password: "{{ lookup('env', 'SYMFONY__ENV__DATABASE_PASSWORD')|default('~', true) }}"
@@ -116,6 +117,7 @@
       postgresql_user:
         name="{{ database_user }}"
         password="{{ database_password }}"
+        encrypted=true
         db={{ database_name }}
         priv=ALL
         login_host="{{ database_host }}"

--- a/root/etc/ansible/templates/parameters.yml.j2
+++ b/root/etc/ansible/templates/parameters.yml.j2
@@ -1,5 +1,6 @@
 parameters:
     database_driver: {{ database_driver }}
+    database_driver_class: {{ database_driver_class }}
     database_host: {{ database_host }}
     database_port: {{ database_port }}
     database_name: {{ database_name }}
@@ -9,7 +10,6 @@ parameters:
     database_table_prefix: wallabag_
     database_socket: null
     database_charset: {{ database_charset }}
-    database_driver_class: null
 
     domain_name: {{ domain_name }}
 

--- a/tests/docker-compose.postgresql.yml
+++ b/tests/docker-compose.postgresql.yml
@@ -10,6 +10,7 @@ services:
       - POSTGRES_USER=my-super-user
       - SYMFONY__ENV__SECRET=F00B4R
       - SYMFONY__ENV__DATABASE_DRIVER=pdo_pgsql
+      - SYMFONY__ENV__DATABASE_DRIVER_CLASS=Wallabag\CoreBundle\Doctrine\DBAL\Driver\CustomPostgreSQLDriver
       - SYMFONY__ENV__DATABASE_HOST=db
       - SYMFONY__ENV__DATABASE_PORT=5432
       - SYMFONY__ENV__DATABASE_NAME=wallabag
@@ -18,7 +19,7 @@ services:
     ports:
       - "127.0.0.1:80:80"
   db:
-    image: postgres:9.6
+    image: postgres:10.3
     environment:
       - POSTGRES_PASSWORD=my-secret-pw
       - POSTGRES_USER=my-super-user


### PR DESCRIPTION
* Add SYMFONY__ENV__DATABASE_DRIVER_CLASS environment variable which can
  be set to the necessary driver class for Postgres 10
* Use this in travis.yml
* Encrypt the password - Postgres 10 no longer allows unencrypted passwords