### PR TITLE
Use alpine:latest instead of alpine:edge for base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:latest
 
 LABEL maintainer "Marvin Steadfast <marvin@xsteadfastx.org>"
 


### PR DESCRIPTION
While investigating of wallabag/wallabag#3723:
- I could not build wallabag docker image with edge
- I succeeded in building with latest
- building with latest resolved wallabag/wallabag#3723

Additionally, alpine recommends against using edge for end users ([0][]).

[0]: https://wiki.alpinelinux.org/wiki/Edge