### PR TITLE
Add redis environmental variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ Default login is `wallabag:wallabag`.
 - `-e SYMFONY__ENV__FOSUSER_REGISTRATION=...`(defaults to "true", enable or disable public user registration)
 - `-e SYMFONY__ENV__FOSUSER_CONFIRMATION=...`(defaults to "true", enable or disable registration confirmation)
 - `-e SYMFONY__ENV__DOMAIN_NAME=...`  defaults to "https://your-wallabag-url-instance.com", the URL of your wallabag instance)
+- `-e SYMFONY__ENV__REDIS_SCHEME=...` (defaults to "tcp", protocol to use to communicate with the target server (tcp, unix, or http))
+- `-e SYMFONY__ENV__REDIS_HOST=...` (defaults to "redis", IP or hostname of the target server)
+- `-e SYMFONY__ENV__REDIS_PORT=...` (defaults to "6379", port of the target host)
+- `-e SYMFONY__ENV__REDIS_PATH=...`(defaults to "~", path of the unix socket file)
+- `-e SYMFONY__ENV__REDIS_PASSWORD=...` (defaults to "~", this is the password defined in the Redis server configuration)
 - `-e POPULATE_DATABASE=...`(defaults to "True". Does the DB has to be populated or is it an existing one)
 
 ## SQLite
@@ -69,11 +74,17 @@ $ docker run --name wallabag --link wallabag-db:wallabag-db -e "POSTGRES_PASSWOR
 
 ## Redis
 
-To use redis support a linked redis container with the name `redis` is needed.
+To use redis with a linked redis container with the name `redis` is needed and none of the `REDIS` environmental variables are needed:
 
  ```
 $ docker run -p 6379:6379 --name redis redis:alpine
 $ docker run -p 80:80 --link redis:redis wallabag/wallabag
+```
+
+To use redis with an external redis host, set the appropriate environmental variables. Example:
+
+```
+$ docker run -p 80:80 -e "SYMFONY__ENV__REDIS_HOST=my.server.hostname" -e "SYMFONY__ENV__REDIS_PASSWORD=my-secret-pw" wallabag/wallabag
 ```
 
 ## Upgrading

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ docker run --name wallabag --link wallabag-db:wallabag-db -e "POSTGRES_PASSWOR
 
 ## Redis
 
-To use redis with a linked redis container with the name `redis` is needed and none of the `REDIS` environmental variables are needed:
+To use redis with a Docker link, a redis container with the name `redis` is needed and none of the `REDIS` environmental variables are needed:
 
  ```
 $ docker run -p 6379:6379 --name redis redis:alpine

--- a/root/etc/ansible/entrypoint.yml
+++ b/root/etc/ansible/entrypoint.yml
@@ -25,6 +25,11 @@
     registration: "{{ lookup('env', 'SYMFONY__ENV__FOSUSER_REGISTRATION')|default('true', true) }}"
     registration_mail_confirmation: "{{ lookup('env', 'SYMFONY__ENV__FOSUSER_CONFIRMATION')|default('true', true) }}"
     domain_name: "{{ lookup('env', 'SYMFONY__ENV__DOMAIN_NAME')|default('https://your-wallabag-url-instance.com', true) }}"
+    redis_scheme: "{{ lookup('env', 'SYMFONY__ENV__REDIS_SCHEME')|default('tcp', true) }}"
+    redis_host: "{{ lookup('env', 'SYMFONY__ENV__REDIS_HOST')|default('redis', true) }}"
+    redis_port: "{{ lookup('env', 'SYMFONY__ENV__REDIS_PORT')|default('6379', true) }}"
+    redis_path: "{{ lookup('env', 'SYMFONY__ENV__REDIS_PATH')|default('~', true) }}"
+    redis_password: "{{ lookup('env', 'SYMFONY__ENV__REDIS_PASSWORD')|default('~', true) }}"
 
   tasks:
 

--- a/root/etc/ansible/templates/parameters.yml.j2
+++ b/root/etc/ansible/templates/parameters.yml.j2
@@ -43,8 +43,8 @@ parameters:
     rabbitmq_prefetch_count: 10
 
     # Redis processing
-    redis_scheme: tcp
-    redis_host: redis
-    redis_port: 6379
-    redis_path: null
-    redis_password: null
+    redis_scheme: {{ redis_scheme }}
+    redis_host: {{ redis_host }}
+    redis_port: {{ redis_port }}
+    redis_path: {{ redis_path }}
+    redis_password: {{ redis_password }}


### PR DESCRIPTION
Allow setting of the Redis options as run time options.

The documentation is updated.