### PR TITLE
Add locale environment variable to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Default login is `wallabag:wallabag`.
 - `-e SYMFONY__ENV__DATABASE_PASSWORD=...` (defaults to "~", this is the password of the database user to use)
 - `-e SYMFONY__ENV__DATABASE_CHARSET=...` (defaults to utf8, this is the database charset to use)
 - `-e SYMFONY__ENV__SECRET=...` (defaults to "ovmpmAWXRCabNlMgzlzFXDYmCFfzGv")
+- `-e SYMFONY__ENV__LOCALE=...` (default to en)
 - `-e SYMFONY__ENV__MAILER_HOST=...`  (defaults to "127.0.0.1", the SMTP host)
 - `-e SYMFONY__ENV__MAILER_USER=...` (defaults to "~", the SMTP user)
 - `-e SYMFONY__ENV__MAILER_PASSWORD=...`(defaults to "~", the SMTP password)


### PR DESCRIPTION
The `SYMFONY__ENV__LOCALE` variable is used in [ansible playbook](root/etc/ansible/entrypoint.yml) but not documented in README.