### PR TITLE
Fix iconv setup to make it support non-ASCII encodings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ LABEL maintainer "Marvin Steadfast <marvin@xsteadfastx.org>"
 
 ARG WALLABAG_VERSION=2.3.8
 
+RUN apk add gnu-libiconv --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted
+ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
+
 RUN set -ex \
  && apk update \
  && apk upgrade --available \


### PR DESCRIPTION
This PR adds 2 instructions to the Docker image build, making sure that `iconv` is setup properly.

This fixes https://github.com/wallabag/wallabag/issues/4011

For more context about the actual underlying issue that this fixes, you can read up
* https://github.com/docker-library/php/issues/240
* https://github.com/docker-library/php/issues/428

Kind regards