### PR TITLE
Fix #124 - Allow to specify at runtime the PHP memory_limit parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Default login is `wallabag:wallabag`.
 - `-e SYMFONY__ENV__SENTRY_DSN=...` (defaults to "~", this is the data source name for sentry)
 - `-e POPULATE_DATABASE=...`(defaults to "True". Does the DB has to be populated or is it an existing one)
 - `-e SYMFONY__ENV__SERVER_NAME=...` (defaults to "Your wallabag instance". Specifies a user-friendly name for the 2FA issuer)
+- `-e PHP_MEMORY_LIMIT_MB=...`(defaults to "128". Amount of Memory in MB for PHP process. Useful to allow bigger import)
 
 ## SQLite
 

--- a/root/etc/ansible/entrypoint.yml
+++ b/root/etc/ansible/entrypoint.yml
@@ -37,6 +37,7 @@
     redis_password: "{{ lookup('env', 'SYMFONY__ENV__REDIS_PASSWORD')|default('~', true) }}"
     sentry_dsn: "{{ lookup('env', 'SYMFONY__ENV__SENTRY_DSN')|default('~', true) }}"
     server_name: "{{ lookup('env', 'SYMFONY__ENV__SERVER_NAME')|default('Your wallabag instance', true) }}"
+    php_memory_limit: "{{ lookup('env', 'PHP_MEMORY_LIMIT_MB')|default('128', true) }}"
 
   tasks:
 
@@ -58,6 +59,11 @@
       template:
         src=templates/parameters.yml.j2
         dest=/var/www/wallabag/app/config/parameters.yml
+
+    - name: write php.ini
+      template:
+        src=templates/php.ini.j2
+        dest=/etc/php7/php.ini
 
     - stat:
         path=/var/www/wallabag/data/db/wallabag.sqlite

--- a/root/etc/ansible/templates/php.ini.j2
+++ b/root/etc/ansible/templates/php.ini.j2
@@ -403,7 +403,7 @@ max_input_time = 60
 
 ; Maximum amount of memory a script may consume (128MB)
 ; http://php.net/memory-limit
-memory_limit = 128M
+memory_limit = {{ php_memory_limit }}M
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;


### PR DESCRIPTION
This PR is fixing #124 by allowing to change when launching the container the memory_limit of PHP.
It is providing the run-time option that was suggested by @djmaze in https://github.com/wallabag/docker/pull/125#issuecomment-430819486_

Let me know if anything need to be modified to get it merged