### PR TITLE
Fix Nginx was not binding on IPv6

### DIFF
--- a/root/etc/nginx/nginx.conf
+++ b/root/etc/nginx/nginx.conf
@@ -31,6 +31,8 @@ http {
     }
 
     server {
+        listen 80;
+        listen [::]:80;
         server_name _;
         root /var/www/wallabag/web;
 


### PR DESCRIPTION
Problem: Nginx is only binding to the IPv4. Deployments with IPv6 require forking the image or overwriting `nginx.conf`.

Solution: Edit `nginx.conf` to listen to both IPv4 and IPv6 by making it listen on `[::]:80`.

Note: This may be related and contradictory to #54