### PR TITLE
Prepare for wallabag 2.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.10
 
 LABEL maintainer "Marvin Steadfast <marvin@xsteadfastx.org>"
 
@@ -43,6 +43,7 @@ RUN set -ex \
       php7-sockets \
       php7-xmlreader \
       php7-tidy \
+      php7-intl \
       py-mysqldb \
       py-psycopg2 \
       py-simplejson \


### PR DESCRIPTION
Problem: I try to build image for wallabag 2.4-dev as of Feb 29, 2020.
The building fails due to two missing packages:

* py-mysqldb
* py-psycopg2

It seems these two packages are included in alpine:3.10, not yet in
alpine:latest. After launching wallabag 2.4-dev, a zhihu page reports
error and wallabag suggests to install php7-intl.

Solution:

* Fix alpine version to 3.10. The reason is also to avoid
CVE-2019-5021 (alpine set root password to NULL). 3.10 is not affected.
In case some users use tag 3.9 and happen to have 3.9.2, then they may
be affected.
* Add php7-intl to meet new requirement