### PR TITLE
Fixes: Provisioner fails in task add mariadb user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex \
  && apk update \
  && apk upgrade --available \
  && apk add \
-      ansible \
+      ansible=2.9.9-r0 \
       curl \
       git \
       libwebp \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex \
  && apk update \
  && apk upgrade --available \
  && apk add \
-      ansible=2.9.9-r0 \
+      ansible=2.7.17-r0 \
       curl \
       git \
       libwebp \


### PR DESCRIPTION
This PR fixes #200.

I believe this issue is related to https://github.com/ansible/ansible/pull/51909. 
I was able to resolve it by pinning the Ansible package to the latest version. 

I would also recommend pinning the other remaining packages to specific versions to ensure reproducible builds. Let me know if you'd like some assistance with that. :-)