### PR TITLE
Do DB migration on every startup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - "master"
+      - "egoexpress-migrate-on-start"
+  workflow_dispatch:
 
 jobs:
   test:

--- a/root/entrypoint.sh
+++ b/root/entrypoint.sh
@@ -15,9 +15,9 @@ migrate () {
 
 if [ "$1" = "wallabag" ];then
     provisioner
-    exec s6-svscan /etc/s6/
     echo "Checking if DB migrations are needed..."
     migrate
+    exec s6-svscan /etc/s6/
 fi
 
 if [ "$1" = "import" ];then

--- a/root/entrypoint.sh
+++ b/root/entrypoint.sh
@@ -8,9 +8,16 @@ provisioner () {
     echo "Provisioner finished."
 }
 
+migrate () {
+    cd /var/www/wallabag/
+    exec su -c "bin/console doctrine:migrations:migrate --env=prod --no-interaction" -s /bin/sh nobody
+}
+
 if [ "$1" = "wallabag" ];then
     provisioner
     exec s6-svscan /etc/s6/
+    echo "Checking if DB migrations are needed..."
+    migrate
 fi
 
 if [ "$1" = "import" ];then
@@ -21,8 +28,9 @@ fi
 
 if [ "$1" = "migrate" ];then
     provisioner
-    cd /var/www/wallabag/
-    exec su -c "bin/console doctrine:migrations:migrate --env=prod --no-interaction" -s /bin/sh nobody
+    echo "Forcing DB migration..."
+    migrate
+    echo "Migration finished.
 fi
 
 exec "$@"


### PR DESCRIPTION
The DB migration is currently only done when explicitely triggered using the 'migrate' argument.
This can cause issues if one forgets to do so.

As running the DB migration is idempotent it would do no harm to run the migration on every container start. This PR contains the changes in the entrypoint file to do that.