### PR TITLE
Fix upgrading to 2.4 requires make and bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,8 @@ RUN set -ex \
       s6 \
       tar \
       tzdata \
+      make \
+      bash \
  && rm -rf /var/cache/apk/* \
  && ln -sf /dev/stdout /var/log/nginx/access.log \
  && ln -sf /dev/stderr /var/log/nginx/error.log \


### PR DESCRIPTION
Running `make update` requires make and bash to be installed.

Closes #237