### PR TITLE
Fix nginx.conf for reverse-proxy with HTTPS

### DIFF
--- a/root/etc/nginx/fastcgi_params
+++ b/root/etc/nginx/fastcgi_params
@@ -10,7 +10,7 @@ fastcgi_param  DOCUMENT_URI       $document_uri;
 fastcgi_param  DOCUMENT_ROOT      $document_root;
 fastcgi_param  SERVER_PROTOCOL    $server_protocol;
 fastcgi_param  REQUEST_SCHEME     $scheme;
-fastcgi_param  HTTPS              $https if_not_empty;
+fastcgi_param  HTTPS              $fe_https;
 
 fastcgi_param  GATEWAY_INTERFACE  CGI/1.1;
 fastcgi_param  SERVER_SOFTWARE    nginx/$nginx_version;

--- a/root/etc/nginx/nginx.conf
+++ b/root/etc/nginx/nginx.conf
@@ -26,7 +26,7 @@ http {
     client_max_body_size 100M;
 
     map $http_x_forwarded_proto $fe_https {
-        default off;
+        default $https;
         https on;
     }
 

--- a/root/etc/nginx/nginx.conf
+++ b/root/etc/nginx/nginx.conf
@@ -25,6 +25,10 @@ http {
     open_file_cache max=100;
     client_max_body_size 100M;
 
+    map $http_x_forwarded_proto $fe_https {
+        default off;
+        https on;
+    }
 
     upstream php-upstream {
         server 127.0.0.1:9000;


### PR DESCRIPTION
Related #77, #264.

This PR changes the `nginx.conf `of wallabag-docker to enable fastcgi HTTPS especially in case of reverse-proxy settings.

The idea is came from @blopware ['s workaround](https://github.com/wallabag/docker/issues/77#issuecomment-609423822) and https://serverfault.com/a/527809. 

