### PR TITLE
wallabag isn't compatible with Composer 2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ RUN set -ex \
  && ln -sf /dev/stderr /var/log/nginx/error.log \
  && curl -s https://getcomposer.org/installer | php \
  && mv composer.phar /usr/local/bin/composer \
+ && composer selfupdate 2.2.10 \
  && git clone --branch $WALLABAG_VERSION --depth 1 https://github.com/wallabag/wallabag.git /var/www/wallabag
 
 COPY root /


### PR DESCRIPTION
Install the latest known 2.2 version instead.

See https://github.com/wallabag/wallabag/pull/5708