### PR TITLE
Automatically build ARM docker images on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,15 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+          
+       # Documentation: https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        
+      # Documentation: https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -43,3 +52,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Support for different platforms, see here: 
+          # https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#-set-the-target-platforms-for-the-build---platform
+          platforms: linux/amd64,linux/arm64,linux/arm/v7


### PR DESCRIPTION
This commit allows Github actions to automatically create and publish Docker images for armv7 and arm64 architecture (e. g. Raspberry Pi).

I really would like to use Wallabag on my Raspberry Pi. Unfortunately there is no official Docker image, only community provided solutions. So I decided to open up this pull request to publish also Docker images for ARM architecture. This should also allow the closure of #277 . 

For further information regarding the changes inside the publish file I also added links to the documentation.