### PR TITLE
Add ability to define `database_table_prefix`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Default login is `wallabag:wallabag`.
 - `-e SYMFONY__ENV__DATABASE_USER=...` (defaults to "root", this is the name of the database user to use)
 - `-e SYMFONY__ENV__DATABASE_PASSWORD=...` (defaults to "~", this is the password of the database user to use)
 - `-e SYMFONY__ENV__DATABASE_CHARSET=...` (defaults to utf8, this is the database charset to use)
+- `-e SYMFONY__ENV__DATABASE_TABLE_PREFIX=...` (defaults to "wallabag_". Specifies the prefix for each database table)
 - `-e SYMFONY__ENV__SECRET=...` (defaults to "ovmpmAWXRCabNlMgzlzFXDYmCFfzGv")
 - `-e SYMFONY__ENV__LOCALE=...` (default to en)
 - `-e SYMFONY__ENV__MAILER_HOST=...`  (defaults to "127.0.0.1", the SMTP host)
@@ -123,6 +124,7 @@ services:
       - SYMFONY__ENV__DATABASE_USER=wallabag
       - SYMFONY__ENV__DATABASE_PASSWORD=wallapass
       - SYMFONY__ENV__DATABASE_CHARSET=utf8mb4
+      - SYMFONY__ENV__DATABASE_TABLE_PREFIX="wallabag_"
       - SYMFONY__ENV__MAILER_HOST=127.0.0.1
       - SYMFONY__ENV__MAILER_USER=~
       - SYMFONY__ENV__MAILER_PASSWORD=~

--- a/root/etc/ansible/entrypoint.yml
+++ b/root/etc/ansible/entrypoint.yml
@@ -14,6 +14,7 @@
     database_root_password_postgres: "{{ lookup('env', 'POSTGRES_PASSWORD') }}"
     database_user: "{{ lookup('env', 'SYMFONY__ENV__DATABASE_USER')|default('root', true) }}"
     database_charset: "{{ lookup('env', 'SYMFONY__ENV__DATABASE_CHARSET')|default('utf8', true) }}"
+    database_table_prefix: "{{ lookup('env', 'SYMFONY__ENV__DATABASE_TABLE_PREFIX')|default('wallabag_', true) }}"
     populate_database: "{{ lookup('env', 'POPULATE_DATABASE')|default(True, true) }}"
     locale: "{{ lookup('env', 'SYMFONY__ENV__LOCALE')|default('en', true) }}"
     secret: "{{ lookup('env', 'SYMFONY__ENV__SECRET')|default('ovmpmAWXRCabNlMgzlzFXDYmCFfzGv', true) }}"

--- a/root/etc/ansible/templates/parameters.yml.j2
+++ b/root/etc/ansible/templates/parameters.yml.j2
@@ -6,7 +6,7 @@ parameters:
     database_user: {{ database_user }}
     database_password: {{ database_password }}
     database_path: "%kernel.root_dir%/../data/db/wallabag.sqlite"
-    database_table_prefix: wallabag_
+    database_table_prefix: {{ database_table_prefix }}
     database_socket: null
     database_charset: {{ database_charset }}
 


### PR DESCRIPTION
For people in need to migrate to the docker version from a previous installed wallabag instance defined with a database prefix.

Should fix https://github.com/wallabag/docker/issues/304