### PR TITLE
Remove fix for gnu-libiconv (already fixed in Alpine 3.16)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@ LABEL maintainer "Marvin Steadfast <marvin@xsteadfastx.org>"
 
 ARG WALLABAG_VERSION=2.5.2
 
-RUN apk add gnu-libiconv --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted
-ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
-
 RUN set -ex \
  && apk update \
  && apk upgrade --available \


### PR DESCRIPTION
The fix was required for Alpine 3.10 but it's already fixed in Alpine 3.16

Original fix and issue => https://github.com/wallabag/docker/commit/503114fcbaedfd4f51311cd2e5e28ca2ac8c94b4
Package with the issue 3.10 => https://pkgs.alpinelinux.org/packages?name=gnu-libiconv&branch=v3.10&repo=&arch=&maintainer=
Fixed package 3.16 => https://pkgs.alpinelinux.org/packages?name=gnu-libiconv&branch=v3.16&repo=&arch=&maintainer=