### PR TITLE
Update README.md to reflect proper volume paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $ docker run -p 80:80 -e "SYMFONY__ENV__DOMAIN_NAME=http://localhost" wallabag/w
 and point your browser to `http://localhost`. For persistent storage you should start the container with a volume:
 
 ```
-$ docker run -v /opt/wallabag/data:/var/www/wallabag/data -v /opt/wallabag/images:/var/www/wallabag/web/assets/images -p 80:80 -e "SYMFONY__ENV__DOMAIN_NAME=http://localhost" wallabag/wallabag
+$ docker run -v /opt/wallabag/data:/var/www/html/data -v /opt/wallabag/assets:/var/www/html/web/assets -p 80:80 -e "SYMFONY__ENV__DOMAIN_NAME=http://localhost" wallabag/wallabag
 ```
 
 ## MariaDB / MySQL


### PR DESCRIPTION
For the SQLite version it seems the volumes recommended here are no longer valid, as they cause errors upon starting. The solution for me was to look into the docker-compose file in the main wallabag repo and deduce the paths actually needed, which then worked. I'm proposing this update to avoid the same headache for future users.