### PR TITLE
Change default workdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,9 @@ RUN set -ex \
  && rm -rf /root/.composer/* /var/www/wallabag/var/cache/* /var/www/wallabag/var/logs/* /var/www/wallabag/var/sessions/* \
  && chown -R nobody:nobody /var/www/wallabag
 
+# Set console entry path
+WORKDIR /var/www/wallabag
+
 EXPOSE 80
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["wallabag"]


### PR DESCRIPTION
Sets the workdir to navigate to the wallabag folder when entering.

Makes it much easier to not have to always drill all the way down each time you first shell in.