### PR TITLE
Add wallabag/bin to PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,8 @@ RUN set -ex \
  && rm -rf /root/.composer/* /var/www/wallabag/var/cache/* /var/www/wallabag/var/logs/* /var/www/wallabag/var/sessions/* \
  && chown -R nobody:nobody /var/www/wallabag
 
+ENV PATH="${PATH}:/var/www/wallabag/bin"
+
 EXPOSE 80
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["wallabag"]


### PR DESCRIPTION
Add Wallabag bin path to environment path so it's commands (i.e `console cache:clear --env=prod`) can be run from anywhere.