### PR TITLE
tests: move docker service start in pytest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,17 +36,14 @@ jobs:
       - name: "Build image"
         run: docker-compose -f tests/docker-compose.${{ matrix.database }}.yml build
 
-      - name: "Run image"
-        run: docker-compose -f tests/docker-compose.${{ matrix.database }}.yml up -d
-
       - name: "Install dependencies"
-        run: pip install pytest requests
-
-      - name: "Check running instance"
-        run: docker ps
-
-      - name: "Wait 60s"
-        run: sleep 60
+        run: pip install pytest pytest-docker requests
 
       - name: "Run tests"
-        run: py.test tests/
+        run: py.test --database=${{ matrix.database }} tests/
+
+      - name: "Get docker logs"
+        run: docker-compose -p "wallabag_${{ matrix.database }}" -f tests/docker-compose.${{ matrix.database }}.yml logs wallabag
+
+      - name: "Cleanup environment"
+        run: docker-compose -p "wallabag_${{ matrix.database }}" -f tests/docker-compose.${{ matrix.database }}.yml down -v

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,4 @@
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption("--database", action="store", default="default")

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,13 +1,53 @@
 import pytest
 import re
 import requests
+import os
 
+from requests.exceptions import ConnectionError
 
-URL = 'http://127.0.0.1:80'
+@pytest.fixture(scope="session")
+def database(pytestconfig):
+    return pytestconfig.getoption("database")
 
+def is_responsive(url):
+    try:
+        response = requests.get(url)
+        if response.status_code == 200:
+            return True
+    except ConnectionError:
+        return False
 
-def test_accessing_login_page():
-    r = requests.get(URL, allow_redirects=True)
+@pytest.fixture(scope="session")
+def docker_compose_project_name(database):
+    return "wallabag_{}".format(database)
+
+@pytest.fixture(scope="session")
+def docker_cleanup():
+    """Disable docker cleanup at the end of tests to get logs outside of pytest"""
+    return False
+
+@pytest.fixture(scope="session")
+def docker_compose_command() -> str:
+    return "docker-compose"
+
+@pytest.fixture(scope="session")
+def docker_compose_file(pytestconfig, database):
+    return os.path.join(str(pytestconfig.rootdir), "tests/", "docker-compose.{}.yml".format(database))
+
+@pytest.fixture(scope="session")
+def wallabag_service(docker_ip, docker_services):
+    """Ensure that wallabag service is up and responsive"""
+
+    # `port_for` takes a container port and returns the corresponding host port
+    port = docker_services.port_for("wallabag", 80)
+    url = "http://{}:{}".format(docker_ip, port)
+    docker_services.wait_until_responsive(
+            timeout=60.0, pause=0.5, check=lambda: is_responsive(url)
+    )
+    return url
+
+def test_accessing_login_page(wallabag_service):
+    r = requests.get(wallabag_service, allow_redirects=True)
 
     assert r.status_code == 200
     assert 'Log in' in r.text
@@ -16,9 +56,9 @@ def test_accessing_login_page():
     assert 'Username' in r.text
 
 
-def test_logging_in():
+def test_logging_in(wallabag_service):
     client = requests.session()
-    r = client.get(URL, allow_redirects=True)
+    r = client.get(wallabag_service, allow_redirects=True)
     jar = r.cookies
 
     # get csrf token
@@ -39,7 +79,7 @@ def test_logging_in():
         '_csrf_token': csrf
     }
 
-    r = client.post(URL + '/login_check', cookies=jar, data=data)
+    r = client.post(wallabag_service + '/login_check', cookies=jar, data=data)
     assert r.status_code == 200
     assert '/unread/list' in r.text
     assert '/starred/list' in r.text


### PR DESCRIPTION
This PR moves logic in charge of starting docker service `wallabag` in pytest, using pytest-docker. This let us avoid putting sleep steps in the CI.

As pytest-docker does not provide a way to print service logs, we still rely on additional calls to `docker-compose logs` and `docker-compose down -v` after tests are finished, see https://github.com/avast/pytest-docker/issues/13