### PR TITLE
Use the release archive instead of the git archive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 COPY root /
 
 RUN set -ex \
- && curl -L -o /tmp/wallabag.tar.gz https://github.com/wallabag/wallabag/archive/$WALLABAG_VERSION.tar.gz \
+ && curl -L -o /tmp/wallabag.tar.gz https://github.com/wallabag/wallabag/releases/download/$WALLABAG_VERSION/wallabag-$WALLABAG_VERSION.tar.gz \
  && tar xvf /tmp/wallabag.tar.gz -C /tmp \
  && mkdir /var/www/wallabag \
  && mv /tmp/wallabag-*/* /var/www/wallabag/ \


### PR DESCRIPTION
~~A proposal to build assets as part of the building of the docker image.~~
Use the release archive as assets are now removed from the repository, see https://github.com/wallabag/wallabag/pull/6982
This will help to avoid having built assets versionned in the git source code and avoid hack like [this one](https://github.com/wallabag/wallabag/pull/6823#issuecomment-1675575464) in the proposal to use Webpack Encore