### PR TITLE
entrypoint: enable configuring PHP memory limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Default login is `wallabag:wallabag`.
 - `-e SYMFONY__ENV__SENTRY_DSN=...` (defaults to "~", this is the data source name for sentry)
 - `-e POPULATE_DATABASE=...`(defaults to "True". Does the DB has to be populated or is it an existing one)
 - `-e SYMFONY__ENV__SERVER_NAME=...` (defaults to "Your wallabag instance". Specifies a user-friendly name for the 2FA issuer)
+- `-e PHP_MEMORY_LIMIT=...` (allows you to change the PHP `memory_limit` value. defaults to 128M, and should be a number and unit, eg. 512K, 128M, 2G, or a number of bytes)
 
 ## SQLite
 

--- a/root/entrypoint.sh
+++ b/root/entrypoint.sh
@@ -24,8 +24,15 @@ provisioner() {
     SYMFONY__ENV__DATABASE_DRIVER=${SYMFONY__ENV__DATABASE_DRIVER:-pdo_sqlite}
     POPULATE_DATABASE=${POPULATE_DATABASE:-True}
 
+    # PHP configuration base and memory limit (default is 128M because that's what php.ini currently ships with)
+    PHP_CONF_BASE_DIR=`php --ini | head -n1 | sed 's/^.*: //'`
+    PHP_MEMORY_LIMIT=${PHP_MEMORY_LIMIT:-128M}
+
     # Replace environment variables
     envsubst < /etc/wallabag/parameters.template.yml > app/config/parameters.yml
+
+    # Configure PHP memory limit
+    sed -i "s/memory_limit\s*=.*/memory_limit=${PHP_MEMORY_LIMIT}/g" $PHP_CONF_BASE_DIR/php.ini
 
     # Wait for external database
     if [ "$SYMFONY__ENV__DATABASE_DRIVER" = "pdo_mysql" ] || [ "$SYMFONY__ENV__DATABASE_DRIVER" = "pdo_pgsql" ] ; then


### PR DESCRIPTION
Adds an environment variable, `PHP_MEMORY_LIMIT`, which overrides the default memory limit as shipped by PHP.

This environment variable, if specified, should be in the format normally expected by PHP (such as 256M or 1G). If unspecified, it defaults to the memory limit specified in php.ini at time of writing, which is 128M. If desired, a more specific default value can be chosen.

Supercedes https://github.com/wallabag/docker/pull/125
Supercedes https://github.com/wallabag/docker/pull/166
Closes https://github.com/wallabag/docker/issues/124