### PR TITLE
Use php81-pecl-imagick from default repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN set -ex \
       php81-mbstring \
       php81-openssl \
       php81-pecl-amqp \
+      php81-pecl-imagick \
       php81-pdo_mysql \
       php81-pdo_pgsql \
       php81-pdo_sqlite \
@@ -54,7 +55,6 @@ RUN set -ex \
       s6 \
       tar \
       tzdata \
-      php81-pecl-imagick --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community \
  && ln -sf /usr/bin/php81 /usr/bin/php \
  && ln -sf /usr/sbin/php-fpm81 /usr/sbin/php-fpm \
  && rm -rf /var/cache/apk/* \


### PR DESCRIPTION
There's no apparent interest in using alpine's edge repository introduced by #376 