### PR TITLE
Update nginx.conf to work with IPv6

### DIFF
--- a/root/etc/nginx/nginx.conf
+++ b/root/etc/nginx/nginx.conf
@@ -36,6 +36,7 @@ http {
 
     server {
         listen 80;
+        listen [::0]:80;
         server_name _;
         root /var/www/wallabag/web;
 


### PR DESCRIPTION
Tested changing this live on a IPv6-only kubernetes cluster. Appears to be working. Adding to docker image.