### PR TITLE
Fix initial setup when using Postgres

### DIFF
--- a/root/entrypoint.sh
+++ b/root/entrypoint.sh
@@ -82,6 +82,7 @@ provisioner() {
             -c "SELECT 1 FROM pg_catalog.pg_tables WHERE schemaname = 'public';")"
         if [ "$TABLES_EXIST" == "" ]; then
             echo "Installing Wallabag ..."
+            exec su -c "bin/console doctrine:migrations:migrate --env=prod --no-interaction" -s /bin/sh nobody
             install_wallabag
         else
             echo "WARN: Postgres database is already configured. Remove the environment variable with root password."

--- a/root/entrypoint.sh
+++ b/root/entrypoint.sh
@@ -64,18 +64,18 @@ provisioner() {
     # Configure Postgres database
     if [ "$SYMFONY__ENV__DATABASE_DRIVER" = "pdo_pgsql" ] && [ "$POPULATE_DATABASE" = "True" ] && [ "$POSTGRES_PASSWORD" != "" ] ; then
         export PGPASSWORD="${POSTGRES_PASSWORD}"
+        USER_EXISTS="$(psql -qAt -h "${SYMFONY__ENV__DATABASE_HOST}" -p "${SYMFONY__ENV__DATABASE_PORT}" -U "${POSTGRES_USER}" \
+            -c "SELECT 1 FROM pg_roles WHERE rolname = '${SYMFONY__ENV__DATABASE_USER}';")"
+        if [ "$USER_EXISTS" != "1" ]; then
+            psql -q -h "${SYMFONY__ENV__DATABASE_HOST}" -p "${SYMFONY__ENV__DATABASE_PORT}" -U "${POSTGRES_USER}" \
+                 -c "CREATE ROLE ${SYMFONY__ENV__DATABASE_USER} with PASSWORD '${SYMFONY__ENV__DATABASE_PASSWORD}' LOGIN;"
+        fi
         DATABASE_EXISTS="$(psql -qAt -h "${SYMFONY__ENV__DATABASE_HOST}" -p "${SYMFONY__ENV__DATABASE_PORT}" -U "${POSTGRES_USER}" \
             -c "SELECT 1 FROM pg_catalog.pg_database WHERE datname = '${SYMFONY__ENV__DATABASE_NAME}';")"
         if [ "$DATABASE_EXISTS" != "1" ]; then
             echo "Configuring the Postgres database ..."
             psql -q -h "${SYMFONY__ENV__DATABASE_HOST}" -p "${SYMFONY__ENV__DATABASE_PORT}" -U "${POSTGRES_USER}" \
                 -c "CREATE DATABASE ${SYMFONY__ENV__DATABASE_NAME};"
-            USER_EXISTS="$(psql -qAt -h "${SYMFONY__ENV__DATABASE_HOST}" -p "${SYMFONY__ENV__DATABASE_PORT}" -U "${POSTGRES_USER}" \
-                -c "SELECT 1 FROM pg_roles WHERE rolname = '${SYMFONY__ENV__DATABASE_USER}';")"
-            if [ "$USER_EXISTS" != "1" ]; then
-                psql -q -h "${SYMFONY__ENV__DATABASE_HOST}" -p "${SYMFONY__ENV__DATABASE_PORT}" -U "${POSTGRES_USER}" \
-                    -c "CREATE ROLE ${SYMFONY__ENV__DATABASE_USER} with PASSWORD '${SYMFONY__ENV__DATABASE_PASSWORD}' LOGIN;"
-            fi
             install_wallabag
         else
             echo "WARN: Postgres database is already configured. Remove the environment variable with root password."

--- a/root/entrypoint.sh
+++ b/root/entrypoint.sh
@@ -76,6 +76,12 @@ provisioner() {
             echo "Configuring the Postgres database ..."
             psql -q -h "${SYMFONY__ENV__DATABASE_HOST}" -p "${SYMFONY__ENV__DATABASE_PORT}" -U "${POSTGRES_USER}" \
                 -c "CREATE DATABASE ${SYMFONY__ENV__DATABASE_NAME};"
+        fi
+
+        TABLES_EXIST="$(psql -qAt -h "${SYMFONY__ENV__DATABASE_HOST}" -p "${SYMFONY__ENV__DATABASE_PORT}" -U "${POSTGRES_USER}" \
+            -c "SELECT 1 FROM pg_catalog.pg_tables WHERE schemaname = 'public';")"
+        if [ "$TABLES_EXIST" == "" ]; then
+            echo "Installing Wallabag ..."
             install_wallabag
         else
             echo "WARN: Postgres database is already configured. Remove the environment variable with root password."


### PR DESCRIPTION
I ran into a few different issues when trying to run this locally in Docker (using Docker Compose as recommended).

The main problem is the migrations are not run on first `docker-compose up`, even if `POPULATE_DATABASE` is set to `True`.  Searching through the issues I was able to find the command to run the migrations (`bin/console doctrine:migrations:migrate --env=prod --no-interaction`), and though it throws errors when run, the migrations do succeed.  (Running the command a second time will show that no migrations need to be run, and no errors occur, so some part of the command must depend on having the correct database structure.)

I also noticed that the database-exists check was failing; when I did a fresh `docker-compose up`, the `entrypoint.sh` script detected that the `wallabag` database already existed, and I confirmed this by inspecting the Postgres instance myself.  My guess is Docker Compose automatically created a database with the same name as the Compose project (which here was also `wallabag`), so by the time the script checks it already exists.  To work around this, I instead added a check if any tables exist, and now it works properly.

One other issue I found is even though the `entrypoint.sh` provisioner runs the `bin/console wallabag:install` command, the default `wallabag:wallabag` user was not created.  I ran the install command again by doing:

```
docker-compose exec wallabag php bin/console wallabag:install --env=prod -n
```

and after that the default user was created.

I haven't dug into either that or the migration command throwing errors, but will shortly either do so or at least create issues for them.

I found a few similar issues (listed below), but all of them have slight variations from my setup or behavior, e.g. using MySQL instead of Postgres, so I'm listing as `Related` rather than `Fixes`.

Related: #291, #236, #286, #154, #377.