### PR TITLE
doc: change docker-compose healthcheck target

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ services:
     volumes:
       - /opt/wallabag/images:/var/www/wallabag/web/assets/images
     healthcheck:
-      test: ["CMD", "wget" ,"--no-verbose", "--tries=1", "--spider", "http://localhost"]
+      test: ["CMD", "wget" ,"--no-verbose", "--tries=1", "--spider", "http://localhost/api/info"]
       interval: 1m
       timeout: 3s
     depends_on:


### PR DESCRIPTION
This PR changes the health check target endpoint used in the docker-compose example as `http://localhost` leads to a 302 redirect to `/login` and a fetch of 5 KB every minute.

`/api/info` is lighter for this purpose.