### PR TITLE
Add support of PHP memory limit in variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Default login is `wallabag:wallabag`.
 - `-e SYMFONY__ENV__SENTRY_DSN=...` (defaults to "~", this is the data source name for sentry)
 - `-e POPULATE_DATABASE=...`(defaults to "True". Does the DB has to be populated or is it an existing one)
 - `-e SYMFONY__ENV__SERVER_NAME=...` (defaults to "Your wallabag instance". Specifies a user-friendly name for the 2FA issuer)
+- `-e PHP_MEMORY_LIMIT=...` (allows you to change the PHP `memory_limit` value. defaults to 128M, and should be a number and unit, eg. 512K, 128M, 2G, or a number of bytes)
 
 ## SQLite
 

--- a/root/entrypoint.sh
+++ b/root/entrypoint.sh
@@ -28,6 +28,7 @@ provisioner() {
 
     # Replace environment variables
     envsubst < /etc/wallabag/parameters.template.yml > app/config/parameters.yml
+    envsubst < /etc/wallabag/php-wallabag.template.ini > /etc/php81/conf.d/50_wallabag.ini
 
     # Wait for external database
     if [ "$SYMFONY__ENV__DATABASE_DRIVER" = "pdo_mysql" ] || [ "$SYMFONY__ENV__DATABASE_DRIVER" = "pdo_pgsql" ] ; then

--- a/root/etc/wallabag/php-wallabag.template.ini
+++ b/root/etc/wallabag/php-wallabag.template.ini
@@ -1,0 +1,1 @@
+memory_limit = ${PHP_MEMORY_LIMIT:-128M}


### PR DESCRIPTION
This PR is based on #374 but it uses envsubst instead of sed-ing php.ini file

Supersedes #374

Fixes #124