### PR TITLE
Add healthcheck to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,8 @@ ENV PATH="${PATH}:/var/www/wallabag/bin"
 # Set console entry path
 WORKDIR /var/www/wallabag
 
+HEALTHCHECK CMD curl --fail --silent --show-error --user-agent healthcheck http://localhost/api/info || exit 1
+
 EXPOSE 80
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["wallabag"]

--- a/README.md
+++ b/README.md
@@ -132,10 +132,6 @@ services:
       - "80"
     volumes:
       - /opt/wallabag/images:/var/www/wallabag/web/assets/images
-    healthcheck:
-      test: ["CMD", "wget" ,"--no-verbose", "--tries=1", "--spider", "http://localhost/api/info"]
-      interval: 1m
-      timeout: 3s
     depends_on:
       - db
       - redis


### PR DESCRIPTION
- Move the healthcheck from the docker-compose example to the actual image. That makes sure all user of the image automatically get the healthcheck.
- Change to `curl --fail || exit 1` as suggested in [docker documentation](https://docs.docker.com/reference/dockerfile/#healthcheck)
- Add `--silent --show-error` so that docker health state contains the output of the HTTP call instead of curl progress bar
- Set the user agent to make the logs more readable