### PR TITLE
Install the opcache extension #162

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN set -ex \
       php81-iconv \
       php81-json \
       php81-mbstring \
+      php81-opcache \
       php81-openssl \
       php81-pecl-amqp \
       php81-pecl-imagick \


### PR DESCRIPTION
On my install, I was seeing ~700ms responses to load an article. Turning this on brings them down to 80-100ms.

The opcache extension should really be enabled by default in all installations. Even on locals for development purposes there's no downside.

I thought about additionally enabling `opcache.validate_timestamps`, which does affect manually exec'ing into the container and hacking files, but given there's no opcache at all this seems like a good first step.