### PR TITLE
introduce FASTCGI_READ_TIMEOUT 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Default login is `wallabag:wallabag`.
 - `-e POPULATE_DATABASE=...`(defaults to "True". Does the DB has to be populated or is it an existing one)
 - `-e SYMFONY__ENV__SERVER_NAME=...` (defaults to "Your wallabag instance". Specifies a user-friendly name for the 2FA issuer)
 - `-e PHP_MEMORY_LIMIT=...` (allows you to change the PHP `memory_limit` value. defaults to 128M, and should be a number and unit, eg. 512K, 128M, 2G, or a number of bytes)
+- `-e FASTCGI_READ_TIMEOUT=...` (allows you to change the timeout how nginx handle cgi backend connection to PHP. default is 300s for 5 minutes)
 
 ## SQLite
 

--- a/root/entrypoint.sh
+++ b/root/entrypoint.sh
@@ -29,6 +29,7 @@ provisioner() {
     # Replace environment variables
     envsubst < /etc/wallabag/parameters.template.yml > app/config/parameters.yml
     envsubst < /etc/wallabag/php-wallabag.template.ini > /etc/php81/conf.d/50_wallabag.ini
+    envsubst < /etc/wallabag/nginx.template.conf > /etc/nginx/nginx.conf 
 
     # Wait for external database
     if [ "$SYMFONY__ENV__DATABASE_DRIVER" = "pdo_mysql" ] || [ "$SYMFONY__ENV__DATABASE_DRIVER" = "pdo_pgsql" ] ; then

--- a/root/entrypoint.sh
+++ b/root/entrypoint.sh
@@ -29,7 +29,7 @@ provisioner() {
     # Replace environment variables
     envsubst < /etc/wallabag/parameters.template.yml > app/config/parameters.yml
     envsubst < /etc/wallabag/php-wallabag.template.ini > /etc/php81/conf.d/50_wallabag.ini
-    envsubst '${FASTCGI_READ_TIMEOUT}' < /etc/wallabag/nginx.template.conf > /etc/nginx/nginx.conf 
+    envsubst '${FASTCGI_READ_TIMEOUT}' < /etc/wallabag/nginx.template.conf | sed 's/\$\${/\${/g' > /etc/nginx/nginx.conf 
 
     # Wait for external database
     if [ "$SYMFONY__ENV__DATABASE_DRIVER" = "pdo_mysql" ] || [ "$SYMFONY__ENV__DATABASE_DRIVER" = "pdo_pgsql" ] ; then

--- a/root/entrypoint.sh
+++ b/root/entrypoint.sh
@@ -29,7 +29,7 @@ provisioner() {
     # Replace environment variables
     envsubst < /etc/wallabag/parameters.template.yml > app/config/parameters.yml
     envsubst < /etc/wallabag/php-wallabag.template.ini > /etc/php81/conf.d/50_wallabag.ini
-    envsubst < /etc/wallabag/nginx.template.conf > /etc/nginx/nginx.conf 
+    envsubst '${FASTCGI_READ_TIMEOUT}' < /etc/wallabag/nginx.template.conf > /etc/nginx/nginx.conf 
 
     # Wait for external database
     if [ "$SYMFONY__ENV__DATABASE_DRIVER" = "pdo_mysql" ] || [ "$SYMFONY__ENV__DATABASE_DRIVER" = "pdo_pgsql" ] ; then

--- a/root/etc/wallabag/nginx.template.conf
+++ b/root/etc/wallabag/nginx.template.conf
@@ -25,8 +25,8 @@ http {
     open_file_cache max=100;
     client_max_body_size 100M;
 
-    map $http_x_forwarded_proto $fe_https {
-        default $https;
+    map $$http_x_forwarded_proto $$fe_https {
+        default $$https;
         https on;
     }
 
@@ -41,12 +41,12 @@ http {
 
         location / {
             # try to serve file directly, fallback to app.php
-            try_files $uri /app.php$is_args$args;
+            try_files $$uri /app.php$$is_args$$args;
         }
 
-        location ~ ^/app\.php(/|$) {
+        location ~ ^/app\.php(/|$$) {
             fastcgi_pass php-upstream;
-            fastcgi_split_path_info ^(.+\.php)(/.*)$;
+            fastcgi_split_path_info ^(.+\.php)(/.*)$$;
             include fastcgi_params;
             # When you are using symlinks to link the document root to the
             # current version of your application, you should pass the real
@@ -55,8 +55,8 @@ http {
             # Otherwise, PHP's OPcache may not properly detect changes to
             # your PHP files (see https://github.com/zendtech/ZendOptimizerPlus/issues/126
             # for more information).
-            fastcgi_param  SCRIPT_FILENAME  $realpath_root$fastcgi_script_name;
-            fastcgi_param DOCUMENT_ROOT $realpath_root;
+            fastcgi_param  SCRIPT_FILENAME  $$realpath_root$$fastcgi_script_name;
+            fastcgi_param DOCUMENT_ROOT $$realpath_root;
             fastcgi_read_timeout ${FASTCGI_READ_TIMEOUT:-300s};
             # Prevents URIs that include the front controller. This will 404:
             # http://domain.tld/app.php/some-path

--- a/root/etc/wallabag/nginx.template.conf
+++ b/root/etc/wallabag/nginx.template.conf
@@ -1,0 +1,73 @@
+user  nginx;
+worker_processes  1;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  2048;
+    multi_accept on;
+    use epoll;
+}
+
+http {
+
+    server_tokens off;
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 15;
+    types_hash_max_size 2048;
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    access_log off;
+    error_log off;
+    gzip on;
+    gzip_disable "msie6";
+    open_file_cache max=100;
+    client_max_body_size 100M;
+
+    map $http_x_forwarded_proto $fe_https {
+        default $https;
+        https on;
+    }
+
+    upstream php-upstream {
+        server 127.0.0.1:9000;
+    }
+
+    server {
+        listen [::]:80 ipv6only=off;
+        server_name _;
+        root /var/www/wallabag/web;
+
+        location / {
+            # try to serve file directly, fallback to app.php
+            try_files $uri /app.php$is_args$args;
+        }
+
+        location ~ ^/app\.php(/|$) {
+            fastcgi_pass php-upstream;
+            fastcgi_split_path_info ^(.+\.php)(/.*)$;
+            include fastcgi_params;
+            # When you are using symlinks to link the document root to the
+            # current version of your application, you should pass the real
+            # application path instead of the path to the symlink to PHP
+            # FPM.
+            # Otherwise, PHP's OPcache may not properly detect changes to
+            # your PHP files (see https://github.com/zendtech/ZendOptimizerPlus/issues/126
+            # for more information).
+            fastcgi_param  SCRIPT_FILENAME  $realpath_root$fastcgi_script_name;
+            fastcgi_param DOCUMENT_ROOT $realpath_root;
+            fastcgi_read_timeout ${FASTCGI_READ_TIMEOUT:-300s};
+            # Prevents URIs that include the front controller. This will 404:
+            # http://domain.tld/app.php/some-path
+            # Remove the internal directive to allow URIs like this
+            internal;
+        }
+
+        access_log /var/log/nginx/access.log;
+        error_log /var/log/nginx/error.log;
+    }
+
+}
+
+daemon off;


### PR DESCRIPTION
fixes: #58 

I want to make `fastcgi_read_timeout` in Nginx configurable, so the user can set another value to prevent connection timeouts between Nginx and PHP.

background: I tried Wallabag and started to use the import function with a 1400 bookmark Json file from Firefox. What I've read so far, Wallabag was never build and tested for that use case, unfortunatelly I have it. With increase the timeout in Nginx and the Memory limit in PHP it works at the end. 
Wallabag is running on Kubernetes cluster, the Ingress has proxy timeout parameter set. The web page returns Error 500 after a while, but when you follow the prod.log Wallabag proceed the bookmarks further in the background. Great!