### PR TITLE
Modify Database Existence Check in entrypoint.sh

### DIFF
--- a/root/entrypoint.sh
+++ b/root/entrypoint.sh
@@ -86,6 +86,11 @@ provisioner() {
                 psql -q -h "${SYMFONY__ENV__DATABASE_HOST}" -p "${SYMFONY__ENV__DATABASE_PORT}" -U "${POSTGRES_USER}" \
                     -c "CREATE ROLE ${SYMFONY__ENV__DATABASE_USER} with PASSWORD '${SYMFONY__ENV__DATABASE_PASSWORD}' LOGIN;"
             fi
+        fi
+        TABLES_EXISTS="$(psql -qAt -h "${SYMFONY__ENV__DATABASE_HOST}" -p "${SYMFONY__ENV__DATABASE_PORT}" -U "${POSTGRES_USER}" \
+            -d ${SYMFONY__ENV__DATABASE_NAME} -c "SELECT 1 FROM pg_catalog.pg_tables WHERE schemaname = 'public' AND tablename like '${DB_PREFIX}%';")"
+        if [ "$TABLES_EXISTS" == "" ]; then
+            echo "Installing Wallabag ..."
             install_wallabag
         else
             echo "WARN: Postgres database is already configured. Remove the environment variable with root password."


### PR DESCRIPTION
In the current implementation, when using a PostgreSQL database, most Docker containers create the database and the associated user role. This leads to the `DATABASE_EXISTS` test in `entrypoint.sh` always evaluating to true, causing Wallabag to not be installed properly.

To address this issue, I propose modifying the test to check if the tables exist instead of just checking if the database exists.

## Changes
1. `DATABASE_EXISTS` only handle the database and role creation
2. Add the `TABLES_EXISTS` test in `entrypoint.sh` to check if the tables exist.
3. If tables not exists run `install_wallabag` function

## Testing
- Tested with PostgreSQL database.
- Verified that Wallabag is installed properly after the changes.

## Related Issues
#412 